### PR TITLE
Update build.release.gradle

### DIFF
--- a/TeamMentor/build.release.gradle
+++ b/TeamMentor/build.release.gradle
@@ -1,10 +1,10 @@
 dependencies {
-    compile project(':FtcRobotController')
-    compile (name: 'RobotCore-release', ext: 'aar')
-    compile (name: 'Hardware-release', ext: 'aar')
-    compile (name: 'FtcCommon-release', ext: 'aar')
-    compile (name:'Analytics-release', ext:'aar')
-    compile (name:'WirelessP2p-release', ext:'aar')
+    implementation project(':FtcRobotController')
+    implementation (name: 'RobotCore-release', ext: 'aar')
+    implementation (name: 'Hardware-release', ext: 'aar')
+    implementation (name: 'FtcCommon-release', ext: 'aar')
+    implementation (name:'Analytics-release', ext:'aar')
+    implementation (name:'WirelessP2p-release', ext:'aar')
     implementation (name: 'tfod-release', ext:'aar')
     implementation (name: 'tensorflow-lite-0.0.0-nightly', ext:'aar')
 }


### PR DESCRIPTION
replace 'compile' with 'implementation' to fix build warnings for TeamMentor folder

Before issuing a pull request, please see the contributing page.
